### PR TITLE
Storage get count

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -74,3 +74,19 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+
+    def get(self, cls, id):
+        """get one object based on class name and id
+        Arguments:
+            cls: string representation of object class name
+            id: string representation of object's id
+        Returns:
+            Object requested. None if not found.
+        """
+        return self.all(cls).get(cls + '.' + id)
+
+    def count(self, cls=None):
+        """get number of objects matching given class name
+        If cls is not given, return number of all objects
+        """
+        return len(self.all(cls))

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -68,3 +68,19 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def get(self, cls, id):
+        """get one object based on class name and id
+        Arguments:
+            cls: string representation of object class name
+            id: string representation of object's id
+        Returns:
+            Object requested. None if not found.
+        """
+        return self.all(cls).get(cls + '.' + id)
+
+    def count(self, cls=None):
+        """get number of objects matching given class name
+        If cls is not given, return number of all objects
+        """
+        return len(self.all(cls))

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -70,6 +70,10 @@ test_db_storage.py'])
 
 class TestFileStorage(unittest.TestCase):
     """Test the FileStorage class"""
+    def tearDown(self):
+        """commit session changes"""
+        models.storage._DBStorage__session.commit()
+
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_returns_dict(self):
         """Test that all returns a dictionaty"""
@@ -78,11 +82,57 @@ class TestFileStorage(unittest.TestCase):
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_all_no_class(self):
         """Test that all returns all rows when no class is passed"""
+        state_inst = State(name="California")
+        amenity_inst = Amenity(name="wifi")
+        models.storage._DBStorage__session.add(state_inst)
+        models.storage._DBStorage__session.add(amenity_inst)
+        models.storage._DBStorage__session.commit()
+        self.assertEqual(len(models.storage.all()), 2)
+        models.storage._DBStorage__session.delete(state_inst)
+        models.storage._DBStorage__session.delete(amenity_inst)
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_new(self):
         """test that new adds an object to the database"""
+        state_inst = State(name="California")
+        models.storage.new(state_inst)
+        models.storage._DBStorage__session.commit()
+        self.assertEqual(len(models.storage.all()), 1)
+        models.storage._DBStorage__session.delete(state_inst)
 
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
-        """Test that save properly saves objects to file.json"""
+        """Test that save properly saves objects to database"""
+        state_inst = State(name="California")
+        models.storage._DBStorage__session.add(state_inst)
+        models.storage._DBStorage__session.commit()
+        self.assertEqual(len(models.storage.all()), 1)
+        models.storage._DBStorage__session.delete(state_inst)
+        models.storage.save()
+        self.assertEqual(len(models.storage.all()), 0)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_get(self):
+        """Test that get properly gets an object from database"""
+        state_inst = State(name="California")
+        models.storage._DBStorage__session.add(state_inst)
+        models.storage._DBStorage__session.commit()
+        self.assertIs(models.storage.get("State", state_inst.id), state_inst)
+        self.assertIs(models.storage.get("State", "wrong id"), None)
+        self.assertIs(models.storage.get("some class", state_inst.id), None)
+        models.storage._DBStorage__session.delete(state_inst)
+
+    @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
+    def test_count(self):
+        """Test that count properly counts an objects from database"""
+        state_inst = State(name="California")
+        amenity_inst = Amenity(name="wifi")
+        models.storage._DBStorage__session.add(state_inst)
+        models.storage._DBStorage__session.add(amenity_inst)
+        models.storage._DBStorage__session.commit()
+        self.assertEqual(models.storage.count(), 2)
+        self.assertEqual(models.storage.count("State"), 1)
+        self.assertEqual(models.storage.count("Amenity"), 1)
+        self.assertEqual(models.storage.count("City"), 0)
+        models.storage._DBStorage__session.delete(state_inst)
+        models.storage._DBStorage__session.delete(amenity_inst)


### PR DESCRIPTION
Update DBStorage and FileStorage, adding two new methods.

A method to retrieve one object:
Prototype: def get(self, cls, id):
cls: class
id: string representing the object ID
Returns the object based on the class and its ID, or None if not found

A method to count the number of objects in storage:
Prototype: def count(self, cls=None):
cls: class (optional)
Returns the number of objects in storage matching the given class. If no class is passed, returns the count of all objects in storage.